### PR TITLE
Scene selector argument for testing

### DIFF
--- a/run.py
+++ b/run.py
@@ -9,10 +9,12 @@ import random
 import argparse
 from config import settings
 from utils import sleep
+from test import testing
 
 # Scenes
 from scenes import SCENES_POOL
 from scenes.wake_up import wake_up_scene
+
 
 # === Parse arguments ===============================================
 
@@ -86,6 +88,4 @@ if __name__ == "__main__":
     if args.test is None:
         main()
     else:
-        for scene in SCENES_POOL:
-            if scene.__name__ in args.test:
-                scene.__call__()
+        testing(args.test)

--- a/run.py
+++ b/run.py
@@ -14,11 +14,13 @@ from utils import sleep
 from scenes import SCENES_POOL
 from scenes.wake_up import wake_up_scene
 
+import scenes
 
 # === Parse arguments ===============================================
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--debug", action="store_true")
+parser.add_argument("--test", nargs='+')
 args = parser.parse_args()
 
 settings.DEBUG = args.debug
@@ -83,4 +85,9 @@ def main():
 # === Run ===========================================================
 
 if __name__ == "__main__":
-    main()
+    if args.test is None:
+        main()
+    else:
+        for scn in SCENES_POOL:
+            if scn.__name__ in args.test:
+                scn.__call__()

--- a/run.py
+++ b/run.py
@@ -14,8 +14,6 @@ from utils import sleep
 from scenes import SCENES_POOL
 from scenes.wake_up import wake_up_scene
 
-import scenes
-
 # === Parse arguments ===============================================
 
 parser = argparse.ArgumentParser()
@@ -88,6 +86,6 @@ if __name__ == "__main__":
     if args.test is None:
         main()
     else:
-        for scn in SCENES_POOL:
-            if scn.__name__ in args.test:
-                scn.__call__()
+        for scene in SCENES_POOL:
+            if scene.__name__ in args.test:
+                scene.__call__()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,22 @@
+"""
+=====================================================================
+  Testing utility
+=====================================================================
+
+Provides scene testing
+"""
+
+# Scenes
+from scenes import SCENES_POOL
+
+
+def testing(scenes):
+    # scene pool is functions, make string list so it's searchable
+    scene_names = {scene.__name__: scene for scene in SCENES_POOL}
+    for scene in scenes:
+        if scene in scene_names:
+            print(f'Testing scene {scene} now:')
+            scene_names[scene].__call__()
+        else:
+            print(f'\nWARNING There is no scene called {scene}')
+    print('\nTesting concluded.')


### PR DESCRIPTION
Specific scenes can now be selected with the --test argument and providing [a list of] the scene name[s], e.g.

run.py --test flower_seller_scene forest_gnomes_scene

Scenes will run in order they are internally registered and health loss etc will be ignored.